### PR TITLE
Feat: Note 도메인 구현

### DIFF
--- a/src/main/java/com/jo0oy/springsecuritydemo/global/auditing/BaseTimeEntity.java
+++ b/src/main/java/com/jo0oy/springsecuritydemo/global/auditing/BaseTimeEntity.java
@@ -2,12 +2,14 @@ package com.jo0oy.springsecuritydemo.global.auditing;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTimeEntity {

--- a/src/main/java/com/jo0oy/springsecuritydemo/note/Note.java
+++ b/src/main/java/com/jo0oy/springsecuritydemo/note/Note.java
@@ -1,0 +1,41 @@
+package com.jo0oy.springsecuritydemo.note;
+
+import com.jo0oy.springsecuritydemo.global.auditing.BaseTimeEntity;
+import com.jo0oy.springsecuritydemo.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "note")
+@Entity
+public class Note extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Builder
+    private Note(String title,
+                 String content,
+                 User user) {
+        this.title = title;
+        this.content = content;
+        this.user = user;
+    }
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/jo0oy/springsecuritydemo/note/NoteRepository.java
+++ b/src/main/java/com/jo0oy/springsecuritydemo/note/NoteRepository.java
@@ -1,0 +1,20 @@
+package com.jo0oy.springsecuritydemo.note;
+
+import com.jo0oy.springsecuritydemo.user.User;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NoteRepository extends JpaRepository<Note, Long> {
+
+    @Query("select n from Note n join fetch n.user order by :property, :sortDirection")
+    List<Note> findAllWithUser(@Param("property") String property, @Param("sortDirection") String sortDirection);
+
+    List<Note> findAllByUserOrderByIdDesc(User user);
+
+    Optional<Note> findByIdAndUser(Long id, User user);
+}

--- a/src/main/java/com/jo0oy/springsecuritydemo/note/NoteService.java
+++ b/src/main/java/com/jo0oy/springsecuritydemo/note/NoteService.java
@@ -1,0 +1,60 @@
+package com.jo0oy.springsecuritydemo.note;
+
+import com.jo0oy.springsecuritydemo.global.exception.UserNotFoundException;
+import com.jo0oy.springsecuritydemo.note.dto.NoteDto;
+import com.jo0oy.springsecuritydemo.note.dto.NoteRegisterDto;
+import com.jo0oy.springsecuritydemo.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class NoteService {
+
+    private final NoteRepository noteRepository;
+
+    @Transactional
+    public NoteDto register(User user, NoteRegisterDto request) {
+        if(Objects.isNull(user)) {
+            throw new UserNotFoundException();
+        }
+
+        return new NoteDto(
+            noteRepository.save(request.toEntity(user))
+        );
+    }
+
+    @Transactional
+    public void delete(User user, Long noteId) {
+        if(Objects.isNull(user)) {
+            throw new UserNotFoundException();
+        }
+
+        noteRepository.findByIdAndUser(noteId, user)
+            .ifPresent(noteRepository::delete);
+    }
+
+    public List<NoteDto> findByUser(User user) {
+        if(Objects.isNull(user)) {
+            throw new UserNotFoundException();
+        }
+
+        if(user.isAdmin()) {
+            return noteRepository.findAllWithUser("id", Sort.Direction.DESC.name())
+                .stream()
+                .map(NoteDto::new)
+                .toList();
+        }
+
+        return noteRepository.findAllByUserOrderByIdDesc(user)
+            .stream()
+            .map(NoteDto::new)
+            .toList();
+    }
+}

--- a/src/main/java/com/jo0oy/springsecuritydemo/note/dto/NoteDto.java
+++ b/src/main/java/com/jo0oy/springsecuritydemo/note/dto/NoteDto.java
@@ -1,0 +1,26 @@
+package com.jo0oy.springsecuritydemo.note.dto;
+
+import com.jo0oy.springsecuritydemo.note.Note;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public record NoteDto(
+    Long id,
+    String title,
+    String content,
+    String username,
+    LocalDateTime createdAt,
+    LocalDateTime modifiedAt
+) {
+    public NoteDto(Note entity) {
+        this(
+            entity.getId(),
+            entity.getTitle(),
+            entity.getContent(),
+            entity.getUser().getUsername(),
+            entity.getCreatedAt(),
+            Objects.isNull(entity.getModifiedAt()) ? entity.getCreatedAt() : entity.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/jo0oy/springsecuritydemo/note/dto/NoteRegisterDto.java
+++ b/src/main/java/com/jo0oy/springsecuritydemo/note/dto/NoteRegisterDto.java
@@ -1,0 +1,17 @@
+package com.jo0oy.springsecuritydemo.note.dto;
+
+import com.jo0oy.springsecuritydemo.note.Note;
+import com.jo0oy.springsecuritydemo.user.User;
+
+public record NoteRegisterDto(
+    String title,
+    String content
+) {
+    public Note toEntity(User user) {
+        return Note.builder()
+            .title(this.title)
+            .content(this.content)
+            .user(user)
+            .build();
+    }
+}

--- a/src/main/java/com/jo0oy/springsecuritydemo/note/web/NoteController.java
+++ b/src/main/java/com/jo0oy/springsecuritydemo/note/web/NoteController.java
@@ -1,0 +1,41 @@
+package com.jo0oy.springsecuritydemo.note.web;
+
+import com.jo0oy.springsecuritydemo.note.NoteService;
+import com.jo0oy.springsecuritydemo.note.dto.NoteRegisterDto;
+import com.jo0oy.springsecuritydemo.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@Controller
+public class NoteController {
+
+    private final NoteService noteService;
+
+    @GetMapping("/note")
+    public String getNote(Authentication authentication, Model model) {
+        User user = (User) authentication.getPrincipal();
+        model.addAttribute("notes", noteService.findByUser(user));
+
+        return "note/index";
+    }
+
+    @PostMapping("/notes")
+    public String registerNote(Authentication authentication, @ModelAttribute NoteRegisterDto request) {
+        User user = (User) authentication.getPrincipal();
+        noteService.register(user, request);
+
+        return "redirect:note";
+    }
+
+    @DeleteMapping("/notes")
+    public String deleteNote(Authentication authentication, @RequestParam Long id) {
+        User user = (User) authentication.getPrincipal();
+        noteService.delete(user, id);
+
+        return "redirect:note";
+    }
+}

--- a/src/main/resources/templates/note/index.html
+++ b/src/main/resources/templates/note/index.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html
+        lang="ko"
+        xmlns:th="http://www.thymeleaf.org"
+>
+<head>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script
+          src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"></script>
+  <head th:insert="fragments.html::header"></head>
+</head>
+<body>
+<header th:insert="fragments.html::nav"></header>
+<!-- 개인 user만 접근할 수 있는 페이지 -->
+<div class="container">
+  <h1>개인노트</h1>
+
+  <!-- 노트 작성 Modal Button -->
+  <button
+          type="button"
+          class="btn btn-primary"
+          data-bs-toggle="modal"
+          data-bs-target="#newNoteModal"
+          data-bs-whatever="@mdo">
+    새 글 쓰기
+  </button>
+
+  <!-- 노트 작성 Modal -->
+  <div
+          class="modal fade"
+          id="newNoteModal"
+          tabindex="-1"
+          aria-labelledby="newNoteModalLabel"
+          aria-hidden="true"
+  >
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="newNoteModalLabel">새 글 쓰기</h5>
+          <button
+                  type="button"
+                  class="btn-close"
+                  data-bs-dismiss="modal"
+                  aria-label="Close">
+          </button>
+        </div>
+        <form
+                th:action="@{/notes}"
+                method="post"
+        >
+          <div class="modal-body">
+            <div class="mb-3">
+              <label for="title" class="col-form-label">제목</label>
+              <input type="text" class="form-control" id="title" name="title">
+            </div>
+            <div class="mb-3">
+              <label for="content" class="col-form-label">내용</label>
+              <textarea class="form-control" rows="20" id="content" name="content"></textarea>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">종료</button>
+            <button type="submit" class="btn btn-primary">저장</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <!-- 노트 내용 조회 -->
+  <div class="row">
+    <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
+      <!-- 노트 개수만큼 반복 -->
+      <div class="border border-dark" th:each="note : ${notes}">
+        <h2 th:text="${note.title}"></h2>
+        <div>
+          <p th:text="${note.content}" style="white-space: pre-wrap;"></p>
+          <form th:action="@{/notes}" th:method="delete">
+            <input type="hidden" name="id" th:value="${note.id}">
+            <!-- 노트 삭제 버튼 -->
+            <button type="submit" class="btn btn-secondary">삭제</button>
+            <!-- 작성일자 표시 -->
+            <span style="margin: 10px 0px;">Posted On
+              <strong th:text="${#temporals.format(note.createdAt, 'yyyy-MM-dd HH:mm:ss')}"></strong>
+            </span>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
- Note 엔티티
   - User 와 N : 1 관계
      - JPA의 `@ManyToOne` `단방향` 매핑 설정 

- NoteRepository
   - 어드민일 경우 사용할 note 리스트 조회 -- > `fetch join` 사용 

- NoteService
   - note 저장, note 삭제, 유저/어드민에 따른 note 리스트 조회 기능 구현
   - DTO 추가

- NoteController 및 Note 뷰 페이지 추가