### PR TITLE
Feat: Notice 도메인 구현

### DIFF
--- a/db/initdb.d/create-tables.sql
+++ b/db/initdb.d/create-tables.sql
@@ -19,10 +19,19 @@ create table note (
                         primary key (id)
 ) engine=InnoDB;
 
+create table notice (
+                      id bigint not null auto_increment,
+                      created_at datetime(6),
+                      modified_at datetime(6),
+                      title varchar(200) not null,
+                      content text,
+                      primary key (id)
+) engine=InnoDB;
+
 ### insert user test data
 ## admin, adminpass
 insert into user(created_at, modified_at, username, password, authority)
-values ('2023-10-20 10:00:30', '2023-10-21 14:01:25', 'admin', '{bcrypt}$2a$10$3CR/6fXZpkQSBLOeqUPrwuYaN/xDYZs2rEletzOS9tETJClAdR.3K', 'ROLE_ADMIN');
+values ('2023-10-05 10:00:30', '2023-10-05 14:01:25', 'admin', '{bcrypt}$2a$10$3CR/6fXZpkQSBLOeqUPrwuYaN/xDYZs2rEletzOS9tETJClAdR.3K', 'ROLE_ADMIN');
 
 ## user1, user1pass
 insert into user(created_at, modified_at, username, password, authority)
@@ -44,3 +53,10 @@ values ('2023-11-02 22:45:10', null, '테스트3', '세번째 테스트 글 내�
 
 insert into note(created_at, modified_at, title, content, user_id)
 values ('2023-11-04 21:25:00', null, '여름 여행 계획', '여름 여행 계획 작성중...', 2);
+
+### insert notice test data
+insert into notice(created_at, modified_at, title, content)
+values ('2023-10-10 09:10:03', null, '환영합니다.', '환영합니다 여러분');
+
+insert into notice(created_at, modified_at, title, content)
+values ('2023-10-11 12:30:00', null, '노트 작성 방법 공지', '1. 회원가입\n2. 로그인\n3. 노트 작성\n4. 저장\n* 본인 외에는 게시글을 볼 수 없습니다.');

--- a/src/main/java/com/jo0oy/springsecuritydemo/config/SecurityConfig.java
+++ b/src/main/java/com/jo0oy/springsecuritydemo/config/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig {
             .formLogin(formLoginConfigurer -> {
                 formLoginConfigurer
                     .loginPage("/login")
-                    .defaultSuccessUrl("/")
+                    .defaultSuccessUrl("/", false)
                     .permitAll();
             })
 

--- a/src/main/java/com/jo0oy/springsecuritydemo/note/NoteRepository.java
+++ b/src/main/java/com/jo0oy/springsecuritydemo/note/NoteRepository.java
@@ -3,15 +3,14 @@ package com.jo0oy.springsecuritydemo.note;
 import com.jo0oy.springsecuritydemo.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface NoteRepository extends JpaRepository<Note, Long> {
 
-    @Query("select n from Note n join fetch n.user order by :property desc")
-    List<Note> findAllWithUserOrderByDesc(@Param("property") String property);
+    @Query("select n from Note n join fetch n.user order by n.id desc")
+    List<Note> findAllWithUserOrderByIdDesc();
 
     List<Note> findAllByUserOrderByIdDesc(User user);
 

--- a/src/main/java/com/jo0oy/springsecuritydemo/note/NoteService.java
+++ b/src/main/java/com/jo0oy/springsecuritydemo/note/NoteService.java
@@ -6,7 +6,6 @@ import com.jo0oy.springsecuritydemo.note.dto.NoteRegisterDto;
 import com.jo0oy.springsecuritydemo.user.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,7 +53,7 @@ public class NoteService {
         }
 
         if(user.isAdmin()) {
-            return noteRepository.findAllWithUserOrderByDesc("id")
+            return noteRepository.findAllWithUserOrderByIdDesc()
                 .stream()
                 .map(NoteDto::new)
                 .toList();

--- a/src/main/java/com/jo0oy/springsecuritydemo/notice/Notice.java
+++ b/src/main/java/com/jo0oy/springsecuritydemo/notice/Notice.java
@@ -1,0 +1,29 @@
+package com.jo0oy.springsecuritydemo.notice;
+
+import com.jo0oy.springsecuritydemo.global.auditing.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "notice")
+@Entity
+public class Notice extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    @Builder
+    private Notice(String title,
+                   String content) {
+        this.title = title;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/jo0oy/springsecuritydemo/notice/NoticeRepository.java
+++ b/src/main/java/com/jo0oy/springsecuritydemo/notice/NoticeRepository.java
@@ -1,0 +1,6 @@
+package com.jo0oy.springsecuritydemo.notice;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+}

--- a/src/main/java/com/jo0oy/springsecuritydemo/notice/NoticeService.java
+++ b/src/main/java/com/jo0oy/springsecuritydemo/notice/NoticeService.java
@@ -1,0 +1,48 @@
+package com.jo0oy.springsecuritydemo.notice;
+
+import com.jo0oy.springsecuritydemo.notice.dto.NoticeDto;
+import com.jo0oy.springsecuritydemo.notice.dto.NoticeRegisterDto;
+import com.jo0oy.springsecuritydemo.user.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+
+    @Transactional
+    public NoticeDto register(NoticeRegisterDto request) {
+        log.info("{} ::: {}", getClass().getSimpleName(), "register");
+
+        return new NoticeDto(
+            noticeRepository.save(request.toEntity())
+        );
+    }
+
+    @Transactional
+    public void delete(Long noticeId) {
+        log.info("{} ::: {}", getClass().getSimpleName(), "delete");
+
+        noticeRepository.findById(noticeId)
+            .ifPresent(noticeRepository::delete);
+    }
+
+    public List<NoticeDto> findAll() {
+        log.info("{} ::: {}", getClass().getSimpleName(), "findAll");
+
+        return noticeRepository.findAll(Sort.by(Sort.Direction.DESC, "id"))
+            .stream()
+            .map(NoticeDto::new)
+            .toList();
+    }
+}

--- a/src/main/java/com/jo0oy/springsecuritydemo/notice/dto/NoticeDto.java
+++ b/src/main/java/com/jo0oy/springsecuritydemo/notice/dto/NoticeDto.java
@@ -1,0 +1,25 @@
+package com.jo0oy.springsecuritydemo.notice.dto;
+
+import com.jo0oy.springsecuritydemo.notice.Notice;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public record NoticeDto(
+    Long id,
+    String title,
+    String content,
+    LocalDateTime createdAt,
+    LocalDateTime modifiedAt
+) {
+    public NoticeDto(Notice entity) {
+        this(
+            entity.getId(),
+            entity.getTitle(),
+            entity.getContent(),
+            entity.getCreatedAt(),
+            Objects.isNull(entity.getModifiedAt())
+                ? entity.getCreatedAt() : entity.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/jo0oy/springsecuritydemo/notice/dto/NoticeRegisterDto.java
+++ b/src/main/java/com/jo0oy/springsecuritydemo/notice/dto/NoticeRegisterDto.java
@@ -1,0 +1,15 @@
+package com.jo0oy.springsecuritydemo.notice.dto;
+
+import com.jo0oy.springsecuritydemo.notice.Notice;
+
+public record NoticeRegisterDto(
+    String title,
+    String content
+) {
+    public Notice toEntity() {
+        return Notice.builder()
+            .title(this.title)
+            .content(this.content)
+            .build();
+    }
+}

--- a/src/main/java/com/jo0oy/springsecuritydemo/notice/web/NoticeController.java
+++ b/src/main/java/com/jo0oy/springsecuritydemo/notice/web/NoticeController.java
@@ -1,0 +1,39 @@
+package com.jo0oy.springsecuritydemo.notice.web;
+
+import com.jo0oy.springsecuritydemo.notice.NoticeService;
+import com.jo0oy.springsecuritydemo.notice.dto.NoticeRegisterDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@Controller
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @GetMapping("/notice")
+    public String notice(Model model) {
+
+        model.addAttribute("notices", noticeService.findAll());
+
+        return "notice/index";
+    }
+
+    @PostMapping("/notices")
+    public String registerNotice(@ModelAttribute NoticeRegisterDto request) {
+
+        noticeService.register(request);
+
+        return "redirect:notice";
+    }
+
+    @DeleteMapping("/notices")
+    public String deleteNotice(@RequestParam Long id) {
+
+        noticeService.delete(id);
+
+        return "redirect:notice";
+    }
+}

--- a/src/main/resources/templates/notice/index.html
+++ b/src/main/resources/templates/notice/index.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html
+        lang="ko"
+        xmlns:th="http://www.thymeleaf.org"
+        xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+>
+<head>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script
+          src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"></script>
+  <head th:insert="fragments.html::header"></head>
+</head>
+<body>
+<header th:insert="fragments.html::nav"></header>
+<div class="container">
+  <h1>공지사항</h1>
+
+  <!-- 공지사항 작성 Modal Button / 어드민만 보임 -->
+  <button
+          type="button"
+          class="btn btn-primary"
+          sec:authorize="hasAnyRole('ROLE_ADMIN')"
+          data-bs-toggle="modal"
+          data-bs-target="#newNoticeModal"
+          data-bs-whatever="@mdo">
+    새 글 쓰기
+  </button>
+
+  <!-- 공지사항 작성 Modal -->
+  <div
+          class="modal fade"
+          id="newNoticeModal"
+          tabindex="-1"
+          aria-labelledby="newNoticeModalLabel"
+          aria-hidden="true"
+  >
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="newNoticeModalLabel">새 글 쓰기</h5>
+          <button
+                  type="button"
+                  class="btn-close"
+                  data-bs-dismiss="modal"
+                  aria-label="Close">
+          </button>
+        </div>
+        <form
+                th:action="@{/notices}"
+                method="POST"
+        >
+          <div class="modal-body">
+            <div class="mb-3">
+              <label for="title" class="col-form-label">제목</label>
+              <input type="text" class="form-control" id="title" name="title">
+            </div>
+            <div class="mb-3">
+              <label for="content" class="col-form-label">내용</label>
+              <textarea class="form-control" rows="20" id="content" name="content"></textarea>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">종료</button>
+            <button type="submit" class="btn btn-primary">저장</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <!-- 공지사항 내용 조회 -->
+  <div class="row">
+    <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
+      <!-- 공지사항 개수만큼 반복 -->
+      <div class="border border-dark" th:each="notice : ${notices}">
+        <h2 th:text="${notice.title}"></h2>
+        <div>
+          <p th:text="${notice.content}" style="white-space: pre-wrap;"></p>
+          <form th:action="@{/notices}" th:method="delete">
+            <input type="hidden" name="id" th:value="${notice.id}">
+            <span style="margin: 10px 0px;">Posted On
+              <strong th:text="${#temporals.format(notice.createdAt, 'yyyy-MM-dd HH:mm:ss')}"></strong>
+            </span>
+            <!-- 공지사항 삭제 버튼 / 어드민만 사용 가능 -->
+            <button
+                    type="submit"
+                    class="btn btn-secondary"
+                    sec:authorize="hasAnyRole('ROLE_ADMIN')"
+            >삭제</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
- Notice 도메인 구현
   - Notice 엔티티
   - NoticeRepository
   - NoticeService
      - 공지 등록/삭제/전체 조회 기능 구현

- DTO 추가
   - NoticeRegisterDto, NoticeDto

- sql 파일에 Notice 테스트 삽입 쿼리문 추가

- 그 외
   - JPQL 을 사용해 정의한 `findAllWithUserOrderByDesc(@Param("property") String property)` : 정렬 동작하지 않음
   - 해결
      - 동적으로 정렬 불가 --> id 기준 내림차순 고정 정렬하는 메서드로  변경
      - 메서드명 변경 및 파라메터 제거 : `findAllWithUserOrderIdByDesc()`